### PR TITLE
Fix broken links across documentation

### DIFF
--- a/fishnet-building-blocks/components/README.md
+++ b/fishnet-building-blocks/components/README.md
@@ -8,4 +8,4 @@ description: >-
 
 Many components aim to make development easier, and quicker. For example, if you wish to synchronize animations, you attach the NetworkAnimator component. There are a wide variety of components to choose from.
 
-Pages within this section summarize what each component accomplishes as well provides more in-depth knowledge to the component's settings. A few select components which offer a significant amount of functionality are covered in the [Broken link](broken-reference "mention").
+Pages within this section summarize what each component accomplishes as well provides more in-depth knowledge to the component's settings. A few select components which offer a significant amount of functionality are covered in the [Guides](../../guides/ "mention").

--- a/guides/features/networked-gameobjects-and-scripts/network-behaviour-guides.md
+++ b/guides/features/networked-gameobjects-and-scripts/network-behaviour-guides.md
@@ -6,7 +6,7 @@ description: >-
 
 # NetworkBehaviour
 
-When inheriting from [NetworkBehaviours ](../../../fishnet-building-blocks/components/network-behaviour-components.md)you are indicating that your script will utilize the network in some way. Once a NetworkBehaviour script is added to an object the [NetworkObject](../../../manual/guides/broken-reference/) component will automatically be attached.
+When inheriting from [NetworkBehaviours ](../../../fishnet-building-blocks/components/network-behaviour-components.md)you are indicating that your script will utilize the network in some way. Once a NetworkBehaviour script is added to an object the [NetworkObject](../../../fishnet-building-blocks/components/network-object.md) component will automatically be attached.
 
 NetworkBehaviours are essential for [Remote Procedure Calls](../network-communication/remote-procedure-calls.md), [Synchronizing](../network-communication/synchronizing/), and having access to vital network information.
 

--- a/guides/features/networked-gameobjects-and-scripts/networkobjects/README.md
+++ b/guides/features/networked-gameobjects-and-scripts/networkobjects/README.md
@@ -8,9 +8,9 @@ description: >-
 
 ## NetworkObject
 
-Any GameObject with a [**NetworkObject**](../../../../manual/guides/broken-reference/) component on it will be considered a "NetworkObject" in these guides going forward.\
+Any GameObject with a [**NetworkObject**](../../../../fishnet-building-blocks/components/network-object.md) component on it will be considered a "NetworkObject" in these guides going forward.\
 \
-Review the [**NetworkObject**](../../../../manual/guides/broken-reference/) component Page for details on the various settings for a **NetworkObject.**
+Review the [**NetworkObject**](../../../../fishnet-building-blocks/components/network-object.md) component Page for details on the various settings for a **NetworkObject.**
 
 When you are to add a [**NetworkBehaviour**](../../../../fishnet-building-blocks/components/network-behaviour-components.md) component to your prefabs or scene objects the NetworkBehaviour will search for a NetworkObject component on the same object, or within parent objects. If a NetworkObject is not found then one will be added automatically to the top-most object.
 
@@ -24,7 +24,7 @@ NetworkObjects that are Instantiated and Spawned using ther ServerManager.Spawn(
 
 Any **NetworkObject** that exists as part of the Scene aka - never instantiated/spawned into the scene, will be considered a "**Scene NetworkObject**" in these guides going forward.\
 \
-"IsSceneObject" property will be marked true on the attached [**NetworkObject**](../../../../manual/guides/broken-reference/) component internally.
+"IsSceneObject" property will be marked true on the attached [**NetworkObject**](../../../../fishnet-building-blocks/components/network-object.md) component internally.
 
 ## Global NetworkObject
 
@@ -38,6 +38,6 @@ Scene objects cannot be marked as global. All global objects must be instantiate
 
 ## Nested NetworkObject
 
-Any [**NetworkObject**](../../../../manual/guides/broken-reference/) that are a child of another [**NetworkObject**](../../../../manual/guides/broken-reference/) will considered a "**Nested NetworkObject**" in these guides going forward.\
+Any [**NetworkObject**](../../../../fishnet-building-blocks/components/network-object.md) that are a child of another [**NetworkObject**](../../../../fishnet-building-blocks/components/network-object.md) will considered a "**Nested NetworkObject**" in these guides going forward.\
 \
-"IsNested" property will be marked true on the attached [**NetworkObject**](../../../../manual/guides/broken-reference/) component internally.
+"IsNested" property will be marked true on the attached [**NetworkObject**](../../../../fishnet-building-blocks/components/network-object.md) component internally.

--- a/guides/features/networked-gameobjects-and-scripts/spawning/object-pooling.md
+++ b/guides/features/networked-gameobjects-and-scripts/spawning/object-pooling.md
@@ -36,7 +36,7 @@ By default the object pool is enabled, but your network objects will only use th
 
 ### Default despawn behavior
 
-On the [NetworkObject](../../../../manual/guides/spawning/broken-reference/) component you can set what the default despawn behavior is for the object where the script is placed.\
+On the [NetworkObject](../../../../fishnet-building-blocks/components/network-object.md) component you can set what the default despawn behavior is for the object where the script is placed.\
 \
 This setting is set to "Destroy" by default, so make sure to switch this over to "Pool" if you want Fish-Networking to automatically use the default object pool.
 

--- a/guides/features/scene-management/persisting-networkobjects.md
+++ b/guides/features/scene-management/persisting-networkobjects.md
@@ -8,7 +8,7 @@ description: >-
 
 ## General
 
-The options available to users to keep [**NetworkObjects**](../../../manual/guides/scene-management/broken-reference/) persisting across scenes depends on the type of NetworkObject.
+The options available to users to keep [**NetworkObjects**](../networked-gameobjects-and-scripts/networkobjects/) persisting across scenes depends on the type of NetworkObject.
 
 ## Spawned NetworkObjects
 

--- a/guides/updating-fishnet/upgrading-api.md
+++ b/guides/updating-fishnet/upgrading-api.md
@@ -248,7 +248,7 @@ Reconcile methods must also now include a Channel parameter as shown.
 private void MyReconcile(ReconcileData rd, bool asServer, Channel channel = Channel.Unreliable)
 ```
 
-For more detailed instructions on these changes see the [prediction guide](../../manual/general/changelog/broken-reference/).
+For more detailed instructions on these changes see the [prediction guide](../features/prediction/).
 
 **TimeManager Fields and Events**
 


### PR DESCRIPTION
Replace GitBook-generated `broken-reference`  with working links across multiple documentation pages.